### PR TITLE
Add Full Stack Fest 2017

### DIFF
--- a/_gridsites/fullstackfest.md
+++ b/_gridsites/fullstackfest.md
@@ -1,0 +1,8 @@
+---
+gridsite-name: "Full Stack Fest 2017"
+gridsite-url: "https://2017.fullstackfest.com"
+gridsite-author: "Swwweet"
+gridsite-author-url: "https://swwweet.com"
+---
+
+Full Stack Fest 2017 is using CSS Grid in the [Speakers page](https://2017.fullstackfest.com/speakers/) and also in the speakers section in the homepage, both with a flexbox fallback.


### PR DESCRIPTION
The 2017 edition of the Full Stack Fest conference is using a simple CSS grid in the speakers home section, and a more complex CSS grid in the speakers page.

Thank you very much!